### PR TITLE
adding sha256 checksum for the direct package downloads

### DIFF
--- a/css/tabs2.css
+++ b/css/tabs2.css
@@ -45,7 +45,7 @@
 #contenttab2 {
 	
 	border-radius: 0 .25em .25em .25em;
-	min-height: 30em;
+	min-height: 34em;
 	position: relative;
 	width: 100%;
 	z-index: 5;

--- a/css/tabs4.css
+++ b/css/tabs4.css
@@ -45,7 +45,7 @@
 #contenttab4 {
 	
 	border-radius: 0 .25em .25em .25em;
-	min-height: 33em;
+	min-height: 38em;
 	position: relative;
 	width: 100%;
 	z-index: 5;

--- a/index.html
+++ b/index.html
@@ -601,10 +601,9 @@
                                <code>alias carta='/Applications/CARTA.app/Contents/MacOS/CARTA'</code><br>
                                Then enter <code>source ~/.zshrc</code> (or <code>source ~/.bashrc</code>) in the terminal.<br> 
                                Now you will be able to start CARTA by simply typing <code>carta</code> in the terminal.
-                            
-                              
                             <br><a href="https://github.com/CARTAvis/carta/releases/download/v2.0/CARTA-v2.0.dmg" 
-                                class="button">DOWNLOAD</a>
+				   class="button">DOWNLOAD</a>
+			    <br><i>SHA256 checksum = b57da0e413b726521ecb3c5b956f19e7202a4f4ac7855f3929cec6307f450813</i>
                           </div>
                       <div id="content-2tab2">
                         <p>The Ubuntu Linux AppImage does not require root access. You simply download, extract, and run it.
@@ -622,6 +621,7 @@
                             <code>APPIMAGE_EXTRACT_AND_RUN=1 ./carta-v2.0-ubuntu.AppImage </code>
                         <br><a href="https://github.com/CARTAvis/carta/releases/download/v2.0/CARTA-v2.0-ubuntu.tgz" 
                             class="button">DOWNLOAD</a>
+			<br><i>SHA256 checksum = 5af69555aeeb97ee410cf2549281f4725180b50e87de0593fd2b954b3ed9d609</i>
                       </div>
 
                       <div id="content-3tab2">
@@ -639,6 +639,8 @@
                             <code>APPIMAGE_EXTRACT_AND_RUN=1 ./carta-v2.0-redhat.AppImage </code>
                         <br><a href="https://github.com/CARTAvis/carta/releases/download/v2.0/CARTA-v2.0-redhat.tgz" 
                             class="button">DOWNLOAD</a>
+			<br><i>SHA256 checksum = c3798460af5b736212fabaf289be62e2548b9a556bd466ec473ce59c4d91b6a8</i>
+
                       </div>
 
 
@@ -779,9 +781,12 @@
                             Now you will be able to start CARTA by simply typing <code>carta</code> in the terminal.
                            
                          <br><a href="https://github.com/CARTAvis/carta/releases/download/v3.0.0-beta.2b/CARTA-v3.0.0-beta.2b.dmg" 
-                             class="button">DOWNLOAD - Intel Mac</a>
+                             class="button">DOWNLOAD - Intel Mac
                              <a href="https://github.com/CARTAvis/carta/releases/download/v3.0.0-beta.2b/CARTA-v3.0.0-beta.2b-arm64.dmg" 
-                             class="button">DOWNLOAD - Apple M1</a>
+				class="button">DOWNLOAD - Apple M1</a>
+			 <br><i>Intel Mac SHA256 checksum = 6a1a74482373add5aeedc57114b42db7c14885ca936be88c9041bbbf57dcb440</i>
+			 <br><i>Apple M1  SHA256 checksum = 7c7613bae8831be02687c9590cf3a8c5cc90c952c54a094eab9b7c859d31ae03</i>
+
                        </div>
                    <div id="content-2tab4">
                      <p>The Ubuntu Linux AppImage does not require root access. You simply download, extract, and run it.
@@ -799,6 +804,7 @@
                          <code>APPIMAGE_EXTRACT_AND_RUN=1 ./CARTA-v3.0.0-beta.2b-ubuntu.AppImage </code>
                      <br><a href="https://github.com/CARTAvis/carta/releases/download/v3.0.0-beta.2b/CARTA-v3.0.0-beta.2b-ubuntu.tgz" 
                          class="button">DOWNLOAD</a>
+                        <br><i>SHA256 checksum = 7006005139ad982bab4262d659d4c0b46e9971a685b8f853b4170c9fc850d80a</i>		     
                    </div>
 
                    <div id="content-3tab4">
@@ -821,6 +827,8 @@
                          class="button">DOWNLOAD-RedHat7</a>
                          <a href="https://github.com/CARTAvis/carta/releases/download/v3.0.0-beta.2b/CARTA-v3.0.0-beta.2b-redhat8.tgz" 
                          class="button">DOWNLOAD-RedHat8</a>
+                        <br><i>RedHat7 SHA256 checksum = 7ca34ef586ce737505478bf8cc506a415715977f41d41b821ee908197ae24450</i>
+			<br><i>RedHat8 SHA256 checksum = 31069db788ccdaa1f6c473f3a35cd8758a52b190809c2d61896edab045fa4e49</i> 
                    </div>
 
 


### PR DESCRIPTION
I just added the sha256 checksum numbers for the direct package downloads. The idea is that a user could verify their download against our original upload for security. A case could be if someone tampered with and then hosted the packages on another website.
At first I was going to put the SHA256 checksum directly to the right of the Download box, but in cases of two Download boxes, it wouldn't fit very well, so I just put it under the box.
The length of the drop down menu needed to be increased in order to fit the extra lines.